### PR TITLE
Fix for transforms on path elements

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -1814,7 +1814,7 @@ static void nsvg__pathArcTo(struct NSVGparser* p, float* cpx, float* cpy, float*
 
 static void nsvg__parsePath(struct NSVGparser* p, const char** attr)
 {
-	const char* s;
+	const char* s = NULL;
 	char cmd;
 	float args[10];
 	int nargs;
@@ -1824,11 +1824,10 @@ static void nsvg__parsePath(struct NSVGparser* p, const char** attr)
 	char closedFlag;
 	int i;
 	char item[64];
-	int dAttrIndex = -1;
 	
 	for (i = 0; attr[i]; i += 2) {
 		if (strcmp(attr[i], "d") == 0) {
-			dAttrIndex = i;
+			s = attr[i + 1];
 		} else {
 			tmp[0] = attr[i];
 			tmp[1] = attr[i + 1];
@@ -1838,10 +1837,8 @@ static void nsvg__parsePath(struct NSVGparser* p, const char** attr)
 		}
 	}
 
-	if(dAttrIndex >= 0)
+	if(s)
 	{
-		s = attr[dAttrIndex + 1];
-
 		nsvg__resetPath(p);
 		cpx = 0; cpy = 0;
 		closedFlag = 0;


### PR DESCRIPTION
Fix for transforms on path elements with 'transform' attributes which appear after the path data 'd' attributes but should still apply to the path.

In some exports, specifically from Inkscape (http://www.inkscape.org) I have seen a bunch of cases where the path element itself has a 'transform' attribute. The transform attribute appears after the 'd' attribute, but is still associated with, and thus should apply to the values from the 'd' attribute data.

Example:

```
<path
   style="..."
   d="..."
   transform="translate(0,-6927.6377)"
   id="path3789"
   inkscape:connector-curvature="0"
   sodipodi:nodetypes="..." />
```

In this case nanosvg would not apply the transform to the values in 'd'. I made a change to always parse the 'd' attribute last, after all transforms in the path element. This fixed the errors I have seen and made the read node values consistent with the data I expect from the export.
