### PR TITLE
Fix for nsvg__parseTransform not parsing multiple transformations

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -1311,10 +1311,10 @@ static int nsvg__parseRotate(float* xform, const char* str)
 	}
 	
 	nsvg__xformSetRotation(t, args[0]/180.0f*NSVG_PI);
-	nsvg__xformPremultiply(0, t);
+	nsvg__xformPremultiply(m, t);
 
 	if (na > 1) {
-		nsvg__xformSetTranslation(xform, args[1], args[2]);
+		nsvg__xformSetTranslation(t, args[1], args[2]);
 		nsvg__xformPremultiply(m, t);
 	}
 
@@ -1325,22 +1325,28 @@ static int nsvg__parseRotate(float* xform, const char* str)
 
 static void nsvg__parseTransform(float* xform, const char* str)
 {
+	float t[6];
+	nsvg__xformIdentity(xform);
 	while (*str)
 	{
 		if (strncmp(str, "matrix", 6) == 0)
-			str += nsvg__parseMatrix(xform, str);
+			str += nsvg__parseMatrix(t, str);
 		else if (strncmp(str, "translate", 9) == 0)
-			str += nsvg__parseTranslate(xform, str);
+			str += nsvg__parseTranslate(t, str);
 		else if (strncmp(str, "scale", 5) == 0)
-			str += nsvg__parseScale(xform, str);
+			str += nsvg__parseScale(t, str);
 		else if (strncmp(str, "rotate", 6) == 0)
-			str += nsvg__parseRotate(xform, str);
+			str += nsvg__parseRotate(t, str);
 		else if (strncmp(str, "skewX", 5) == 0)
-			str += nsvg__parseSkewX(xform, str);
+			str += nsvg__parseSkewX(t, str);
 		else if (strncmp(str, "skewY", 5) == 0)
-			str += nsvg__parseSkewY(xform, str);
-		else
+			str += nsvg__parseSkewY(t, str);
+		else{
 			++str;
+			continue;
+		}
+		
+		nsvg__xformPremultiply(xform, t);
 	}
 }
 


### PR DESCRIPTION
nsvg__parseTransform, while parsing all transforms within the transform node, would only apply the last transform parsed. The specific cases I encountered were translations and scales. Whichever was last was the only transformation applied, however they should all be applied: http://www.w3.org/TR/SVG/coords.html#TransformAttribute

Also snuck into this commit were local changes I had for what appears to be a bug in the nsvg__parseRotation which I outlined here: https://github.com/memononen/nanosvg/issues/9

If I can provide any information or improve this further in any way, please let me know.

Bryan
