### PR TITLE
Bug fix for rotation handling. 

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -1326,15 +1326,15 @@ static int nsvg__parseRotate(float* xform, const char* str)
 
 	if (na > 1) {
 		nsvg__xformSetTranslation(t, -args[1], -args[2]);
-		nsvg__xformPremultiply(m, t);
+		nsvg__xformMultiply(m, t);
 	}
-	
+
 	nsvg__xformSetRotation(t, args[0]/180.0f*NSVG_PI);
-	nsvg__xformPremultiply(m, t);
+	nsvg__xformMultiply(m, t);
 
 	if (na > 1) {
 		nsvg__xformSetTranslation(t, args[1], args[2]);
-		nsvg__xformPremultiply(m, t);
+		nsvg__xformMultiply(m, t);
 	}
 
 	memcpy(xform, m, sizeof(float)*6);


### PR DESCRIPTION
Bug fix for rotation handling. We were doing [T][R0][T-1] instead of [T-.][R0][T] because of the premultiply in nsvg__parseRotate. This was causing the resulting translation to be wrong.

(see http://www.euclideanspace.com/maths/geometry/affine/aroundPoint/matrix2d/)
