### PR TITLE
Fix for C89 compilers

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -436,11 +436,11 @@ static void nsvg__xformMultiply(float* t, float* s)
 static void nsvg__xformInverse(float* inv, float* t)
 {
 	double det = (double)t[0] * t[3] - (double)t[2] * t[1];
+	double invdet = 1.0 / det;
 	if (det > -1e-6 && det < -1e-6) {
 		nsvg__xformIdentity(t);
 		return;
 	}
-	double invdet = 1.0 / det;
 	inv[0] = (float)(t[3] * invdet);
 	inv[2] = (float)(-t[2] * invdet);
 	inv[4] = (float)(((double)t[2] * t[5] - (double)t[3] * t[4]) * invdet);


### PR DESCRIPTION
In compilers that only support C89 the variables must be declared first. I sometimes have to build in VS2012, where the invdet declaration after the if block causes a build error. Moving that line up fixes the problem.
