### PR TITLE
Added support for named groups

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -133,6 +133,14 @@ typedef struct NSVGpath
 	struct NSVGpath* next;		// Pointer to next path, or NULL if last element.
 } NSVGpath;
 
+typedef struct NSVGgroup
+{
+	char id[64];
+	void* userData;
+	NSVGgroup* parent;			// Pointer to parent group or NULL
+	NSVGgroup* next;			// Pointer to next group or NULL
+} NSVGgroup;
+
 typedef struct NSVGshape
 {
 	char id[64];				// Optional 'id' attr of the shape or its group
@@ -150,6 +158,7 @@ typedef struct NSVGshape
 	unsigned char flags;		// Logical or of NSVG_FLAGS_* flags
 	float bounds[4];			// Tight bounding box of the shape [minx,miny,maxx,maxy].
 	NSVGpath* paths;			// Linked list of paths in the image.
+	NSVGgroup* group;			// Pointer to parent group or NULL
 	struct NSVGshape* next;		// Pointer to next shape, or NULL if last element.
 } NSVGshape;
 
@@ -158,6 +167,7 @@ typedef struct NSVGimage
 	float width;				// Width of the image.
 	float height;				// Height of the image.
 	NSVGshape* shapes;			// Linked list of shapes in the image.
+	NSVGgroup* groups;			// Linked list of all groups in the image
 } NSVGimage;
 
 // Parses SVG file from a file, returns SVG image as paths.
@@ -423,6 +433,7 @@ typedef struct NSVGattrib
 	char hasFill;
 	char hasStroke;
 	char visible;
+	NSVGgroup* group;
 } NSVGattrib;
 
 typedef struct NSVGparser
@@ -605,7 +616,7 @@ static NSVGparser* nsvg__createParser()
 	p = (NSVGparser*)malloc(sizeof(NSVGparser));
 	if (p == NULL) goto error;
 	memset(p, 0, sizeof(NSVGparser));
-
+	
 	p->image = (NSVGimage*)malloc(sizeof(NSVGimage));
 	if (p->image == NULL) goto error;
 	memset(p->image, 0, sizeof(NSVGimage));
@@ -734,6 +745,7 @@ static void nsvg__pushAttr(NSVGparser* p)
 	if (p->attrHead < NSVG_MAX_ATTR-1) {
 		p->attrHead++;
 		memcpy(&p->attr[p->attrHead], &p->attr[p->attrHead-1], sizeof(NSVGattrib));
+		memset(&p->attr[p->attrHead], 0, sizeof(p->attr[p->attrHead].id));
 	}
 }
 
@@ -933,6 +945,7 @@ static void nsvg__addShape(NSVGparser* p)
 	memset(shape, 0, sizeof(NSVGshape));
 
 	memcpy(shape->id, attr->id, sizeof shape->id);
+	shape->group = attr->group;
 	scale = nsvg__getAverageScale(attr->xform);
 	shape->strokeWidth = attr->strokeWidth * scale;
 	shape->strokeDashOffset = attr->strokeDashOffset * scale;
@@ -2578,6 +2591,29 @@ static void nsvg__parseGradientStop(NSVGparser* p, const char** attr)
 	stop->offset = curAttr->stopOffset;
 }
 
+static void nsvg__parseGroup(NSVGparser* p, const char** attrs)
+{
+	NSVGgroup* group, *g;
+	NSVGattrib* attr = nsvg__getAttr(p);
+	
+	nsvg__parseAttribs(p, attrs);
+	if (!*attr->id) //skip anonymous groups
+		return;
+	
+	group = (NSVGgroup*)malloc(sizeof NSVGgroup);
+	memset(group, 0, sizeof NSVGgroup);
+	memcpy(group->id, attr->id, sizeof(group->id));
+	group->parent = attr->group;
+	attr->group = group;
+	
+	if (!p->image->groups) 
+		p->image->groups = group;
+	else {
+		for (g = p->image->groups; g->next; g = g->next);
+		g->next = group;
+	}	
+}
+
 static void nsvg__startElement(void* ud, const char* el, const char** attr)
 {
 	NSVGparser* p = (NSVGparser*)ud;
@@ -2596,7 +2632,7 @@ static void nsvg__startElement(void* ud, const char* el, const char** attr)
 
 	if (strcmp(el, "g") == 0) {
 		nsvg__pushAttr(p);
-		nsvg__parseAttribs(p, attr);
+		nsvg__parseGroup(p, attr);
 	} else if (strcmp(el, "path") == 0) {
 		if (p->pathFlag)	// Do not allow nested paths.
 			return;
@@ -2847,6 +2883,7 @@ error:
 void nsvgDelete(NSVGimage* image)
 {
 	NSVGshape *snext, *shape;
+	NSVGgroup *group, *gnext;
 	if (image == NULL) return;
 	shape = image->shapes;
 	while (shape != NULL) {
@@ -2856,6 +2893,12 @@ void nsvgDelete(NSVGimage* image)
 		nsvg__deletePaint(&shape->stroke);
 		free(shape);
 		shape = snext;
+	}
+	group = image->groups;
+	while (group != NULL) {
+		gnext = group->next;
+		free(group);
+		group = gnext;
 	}
 	free(image);
 }


### PR DESCRIPTION
I have added support for named groups (<g>). Each NSVGshape now remembers its group. Each NSVGgroup knows its parent group. List of all groups is accessible from NSVGimage. Only groups with filled id are used.

Also I removed storing group id under shape id when shape id is empty. It's confusing and group names are now accessible through NSVGshape::group.

Having groups is very useful for structuring the document. For example I have a svg viewer which shows all groups in the tree structure and allows them to turn on/off.