### PR TITLE
Fix two errors found with AFL

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -282,7 +282,7 @@ static void nsvg__parseElement(char* s,
 		char* name = NULL;
 		char* value = NULL;
 
-		// Skip white space before the attrib char* name = NULL;
+		// Skip white space before the attrib name
 		while (*s && nsvg__isspace(*s)) s++;
 		if (!*s) break;
 		if (*s == '/') {

--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -279,6 +279,9 @@ static void nsvg__parseElement(char* s,
 
 	// Get attribs
 	while (!end && *s && nattr < NSVG_XML_MAX_ATTRIBS-3) {
+		char* attr_ptr = NULL;
+		char* value_ptr = NULL;
+
 		// Skip white space before the attrib name
 		while (*s && nsvg__isspace(*s)) s++;
 		if (!*s) break;
@@ -286,7 +289,7 @@ static void nsvg__parseElement(char* s,
 			end = 1;
 			break;
 		}
-		attr[nattr++] = s;
+		attr_ptr = s;
 		// Find end of the attrib name.
 		while (*s && !nsvg__isspace(*s) && *s != '=') s++;
 		if (*s) { *s++ = '\0'; }
@@ -296,9 +299,15 @@ static void nsvg__parseElement(char* s,
 		quote = *s;
 		s++;
 		// Store value and find the end of it.
-		attr[nattr++] = s;
+		value_ptr = s;
 		while (*s && *s != quote) s++;
 		if (*s) { *s++ = '\0'; }
+
+		// Store only well formed attributes
+		if (attr_ptr && value_ptr) {
+			attr[nattr++] = attr_ptr;
+			attr[nattr++] = value_ptr;
+		}
 	}
 
 	// List terminator

--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -279,17 +279,17 @@ static void nsvg__parseElement(char* s,
 
 	// Get attribs
 	while (!end && *s && nattr < NSVG_XML_MAX_ATTRIBS-3) {
-		char* attr_ptr = NULL;
-		char* value_ptr = NULL;
+		char* name = NULL;
+		char* value = NULL;
 
-		// Skip white space before the attrib name
+		// Skip white space before the attrib char* name = NULL;
 		while (*s && nsvg__isspace(*s)) s++;
 		if (!*s) break;
 		if (*s == '/') {
 			end = 1;
 			break;
 		}
-		attr_ptr = s;
+		name = s;
 		// Find end of the attrib name.
 		while (*s && !nsvg__isspace(*s) && *s != '=') s++;
 		if (*s) { *s++ = '\0'; }
@@ -299,14 +299,14 @@ static void nsvg__parseElement(char* s,
 		quote = *s;
 		s++;
 		// Store value and find the end of it.
-		value_ptr = s;
+		value = s;
 		while (*s && *s != quote) s++;
 		if (*s) { *s++ = '\0'; }
 
 		// Store only well formed attributes
-		if (attr_ptr && value_ptr) {
-			attr[nattr++] = attr_ptr;
-			attr[nattr++] = value_ptr;
+		if (name && value) {
+			attr[nattr++] = name;
+			attr[nattr++] = value;
 		}
 	}
 

--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -1388,7 +1388,7 @@ static NSVGcoordinate nsvg__parseCoordinateRaw(const char* str)
 {
 	NSVGcoordinate coord = {0, NSVG_UNITS_USER};
 	char units[32]="";
-	sscanf(str, "%f%s", &coord.value, units);
+	sscanf(str, "%f%31s", &coord.value, units);
 	coord.units = nsvg__parseUnits(units);
 	return coord;
 }
@@ -2799,7 +2799,7 @@ NSVGimage* nsvgParse(char* input, const char* units, float dpi)
 	p->dpi = dpi;
 
 	nsvg__parseXML(input, nsvg__startElement, nsvg__endElement, nsvg__content, p);
-  
+
 	// Scale to viewBox
 	nsvg__scaleToViewbox(p, units);
 


### PR DESCRIPTION
The project was fuzzed using AFL with ASAN. We wrote a testing program to make the library parse the input file provided by AFL. We analyzed the crashes and found two errors. We fixed them, checked for regression and then a new AFL run reported no crashes.