### PR TITLE
Add support for per-thread locale 

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -178,9 +178,11 @@ void nsvgDelete(NSVGimage* image);
 
 #ifdef NANOSVG_IMPLEMENTATION
 
+#define _XOPEN_SOURCE 700
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
+#include <locale.h>
 
 #define NSVG_PI (3.14159265358979323846264338327f)
 #define NSVG_KAPPA90 (0.5522847493f)	// Length proportional to radius of a cubic bezier handle for 90deg arcs.
@@ -203,8 +205,12 @@ void nsvgDelete(NSVGimage* image);
 	#else
 	#define NSVG_INLINE
 	#endif
+	#define NSVG_USELOCALE _configthreadlocale(_ENABLE_PER_THREAD_LOCALE); setlocale(LC_ALL, "C")
+	#define NSVG_RESTORELOCALE _configthreadlocale(_DISABLE_PER_THREAD_LOCALE); setlocale(LC_ALL, "")
 #else
 	#define NSVG_INLINE inline
+	#define NSVG_USELOCALE locale_t l = newlocale(LC_ALL_MASK, "C", (locale_t)0); locale_t previous = uselocale(l)
+	#define NSVG_RESTORELOCALE uselocale(previous); freelocale(l)
 #endif
 
 
@@ -2798,8 +2804,10 @@ NSVGimage* nsvgParse(char* input, const char* units, float dpi)
 	NSVGparser* p;
 	NSVGimage* ret = 0;
 
+	NSVG_USELOCALE;
 	p = nsvg__createParser();
 	if (p == NULL) {
+		NSVG_RESTORELOCALE;
 		return NULL;
 	}
 	p->dpi = dpi;
@@ -2813,7 +2821,7 @@ NSVGimage* nsvgParse(char* input, const char* units, float dpi)
 	p->image = NULL;
 
 	nsvg__deleteParser(p);
-
+	NSVG_RESTORELOCALE;
 	return ret;
 }
 


### PR DESCRIPTION
Use "C" locale for floating point number parsing
The basic idea is to enable per thread locale mode (supported on POSIX system and Windows)
Then upon parsing an image, we set up a "C" locale (default expected for svg file's number format), and restore to the previous locale when leaving the function.

Since it's per thread, it does not affect the whole program's defined locale.