### PR TITLE
type fix: change nsvg__parseLineJoin() default value to NSVG_JOIN_MITER

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -1650,7 +1650,7 @@ static char nsvg__parseLineJoin(const char* str)
 	else if (strcmp(str, "bevel") == 0)
 		return NSVG_JOIN_BEVEL;
 	// TODO: handle inherit.
-	return NSVG_CAP_BUTT;
+	return NSVG_JOIN_MITER;
 }
 
 static char nsvg__parseFillRule(const char* str)


### PR DESCRIPTION
Very trivial type fix.

Both NSVG_CAP_BUTT and NSVG_JOIN_MITER is 0, so no functionality change.

Found when working on porting your excellent project to golang.