### PR TITLE
fix handling of <defs> after <g>

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -844,6 +844,7 @@ static NSVGgradient* nsvg__createGradient(NSVGparser* p, NSVGshape* shape, NSVGg
 	float ox, oy, sw, sh, sl;
 	int nstops = 0;
 
+	if (link == NULL) return NULL;
 	data = nsvg__findGradientData(p, link->id);
 	if (data == NULL) return NULL;
 
@@ -1009,7 +1010,10 @@ static void nsvg__addShape(NSVGparser* p)
 	} else if (attr->hasFill == 2) {
 		shape->fill.type = NSVG_PAINT_GRADIENT_LINK;
 		shape->fill.gradientLink = nsvg__createGradientLink(attr->fillGradient, attr->xform);
-		if (shape->fill.gradientLink == NULL) goto error;
+		if (shape->fill.gradientLink == NULL) {
+			shape->fill.type = NSVG_PAINT_NONE;
+			goto error;
+		}
 	}
 
 	// Set stroke
@@ -1022,7 +1026,10 @@ static void nsvg__addShape(NSVGparser* p)
 	} else if (attr->hasStroke == 2) {
 		shape->stroke.type = NSVG_PAINT_GRADIENT_LINK;
 		shape->stroke.gradientLink = nsvg__createGradientLink(attr->strokeGradient, attr->xform);
-		if (shape->stroke.gradientLink == NULL) goto error;
+		if (shape->stroke.gradientLink == NULL) {
+			shape->stroke.type = NSVG_PAINT_NONE;
+			goto error;
+		}
 	}
 
 	// Set flags
@@ -2764,7 +2771,9 @@ static void nsvg__assignGradients(NSVGparser* p)
 			NSVGgradientLink* link = shape->fill.gradientLink;
 			shape->fill.gradient = nsvg__createGradient(
 				p, shape, link, &shape->fill.type);
-			free(link);
+			if (link != NULL) {
+				free(link);
+			}
 			if (shape->fill.gradient == NULL) {
 				shape->fill.type = NSVG_PAINT_NONE;
 			}
@@ -2773,7 +2782,9 @@ static void nsvg__assignGradients(NSVGparser* p)
 			NSVGgradientLink* link = shape->stroke.gradientLink;
 			shape->stroke.gradient = nsvg__createGradient(
 				p, shape, link, &shape->stroke.type);
-			free(link);
+			if (link != NULL) {
+				free(link);
+			}
 			if (shape->stroke.gradient == NULL) {
 				shape->stroke.type = NSVG_PAINT_NONE;
 			}


### PR DESCRIPTION
Some SVGs (like the ones exported from <a href="https://affinity.serif.com/de/designer/">Affinity Designer</a>) have their `<defs>` tags after their `<g>` tags. Example file:

[gradient-circles.svg.zip](https://github.com/memononen/nanosvg/files/2175642/gradient-circles.svg.zip)

Currently, NanoSVG will miss those tags as they're not yet available at the time `<g>` is parsed (i.e. the shapes needing those gradient will not be painted). This PR fixes this by relaying the resolution of gradient names to a point when the whole XML has been parsed.

Rendering without PR (background not part of NanoSVG rendering):

<img width="197" alt="without-pr" src="https://user-images.githubusercontent.com/11859538/42446370-46d7a242-8376-11e8-9724-b48b92e23507.png">

Rendering with PR (background not part of NanoSVG rendering):

<img width="213" alt="with-pr" src="https://user-images.githubusercontent.com/11859538/42446374-4a2c3bce-8376-11e8-98cf-9f38a30e504b.png">
