### PR TITLE
Add option for cpp symbol export

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -29,8 +29,10 @@
 #ifndef NANOSVG_H
 #define NANOSVG_H
 
+#ifndef NANOSVG_CPLUSPLUS
 #ifdef __cplusplus
 extern "C" {
+#endif
 #endif
 
 // NanoSVG is a simple stupid single-header-file SVG parse. The output of the parser is a list of cubic bezier shapes.
@@ -173,8 +175,10 @@ NSVGpath* nsvgDuplicatePath(NSVGpath* p);
 // Deletes an image.
 void nsvgDelete(NSVGimage* image);
 
+#ifndef NANOSVG_CPLUSPLUS
 #ifdef __cplusplus
 }
+#endif
 #endif
 
 #endif // NANOSVG_H

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -25,8 +25,10 @@
 #ifndef NANOSVGRAST_H
 #define NANOSVGRAST_H
 
+#ifndef NANOSVGRAST_CPLUSPLUS
 #ifdef __cplusplus
 extern "C" {
+#endif
 #endif
 
 typedef struct NSVGrasterizer NSVGrasterizer;
@@ -64,8 +66,10 @@ void nsvgRasterize(NSVGrasterizer* r,
 void nsvgDeleteRasterizer(NSVGrasterizer*);
 
 
+#ifndef NANOSVGRAST_CPLUSPLUS
 #ifdef __cplusplus
 }
+#endif
 #endif
 
 #endif // NANOSVGRAST_H


### PR DESCRIPTION
Currently working on a project, where I need to have two versions of NanoSVG in one binary, I  ran into the problem of conflicting problems due to duplicate symbols.

Basically, even if you're using two NanoSVG versions inside two different C++ namespaces, certain symbols get exported as C symbols via `extern C`, making them global.

This PR adds two optional defines `NANOSVG_CPLUSPLUS` and `NANOSVGRAST_CPLUSPLUS`. If not defined (default), everything is as now: symbols are exported as C symbols on C++. If defined though, no `extern C` is used, and NanoSVGs global symbols can be embedded in a C++ namespace.