### PR TITLE
Made the nanosvgrast example compatible with c++ using gcc

### DIFF
--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -41,7 +41,7 @@ typedef struct NSVGrasterizer NSVGrasterizer;
 	// Create rasterizer (can be used to render multiple images).
 	struct NSVGrasterizer* rast = nsvgCreateRasterizer();
 	// Allocate memory for image
-	unsigned char* img = malloc(w*h*4);
+	unsigned char* img = (unsigned char*) malloc(w*h*4);
 	// Rasterize
 	nsvgRasterize(rast, image, 0,0,1, img, w, h, w*4);
 */


### PR DESCRIPTION
If compiling C++ the gcc complains if the result of malloc (which returns void *) is assigned to a pointer of a different type without casting. 
The example that comes with the comments in nanosvgrast.h did this and therefore could cause the compiler to complain => Added an explicit cast which makes the example work without any error/warning.