### PR TITLE
Resolved the cppcheck style warnings

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -819,14 +819,13 @@ static NSVGgradientData* nsvg__findGradientData(NSVGparser* p, const char* id)
 static NSVGgradient* nsvg__createGradient(NSVGparser* p, const char* id, const float* localBounds, char* paintType)
 {
 	NSVGattrib* attr = nsvg__getAttr(p);
-	NSVGgradientData* data = NULL;
 	NSVGgradientData* ref = NULL;
 	NSVGgradientStop* stops = NULL;
 	NSVGgradient* grad;
 	float ox, oy, sw, sh, sl;
 	int nstops = 0;
 
-	data = nsvg__findGradientData(p, id);
+	NSVGgradientData* data = nsvg__findGradientData(p, id);
 	if (data == NULL) return NULL;
 
 	// TODO: use ref to fill in all unset values too.
@@ -2899,12 +2898,11 @@ NSVGimage* nsvgParse(char* input, const char* units, float dpi)
 
 NSVGimage* nsvgParseFromFile(const char* filename, const char* units, float dpi)
 {
-	FILE* fp = NULL;
 	size_t size;
 	char* data = NULL;
 	NSVGimage* image = NULL;
 
-	fp = fopen(filename, "rb");
+	FILE* fp = fopen(filename, "rb");
 	if (!fp) goto error;
 	fseek(fp, 0, SEEK_END);
 	size = ftell(fp);


### PR DESCRIPTION
cppcheck is a popular tool that performs static code analysis outputting warnings if constructs are error-prone or do not make sense. In the project wxMaxima some of these warnings have proven to be extremely useful . Getting rid of any warnings that can be fixed makes things easier for users who want cppcheck to find bugs in their code.

This commit resolves the following warnings:

      nanosvg.h:829: style: Variable 'data' is reassigned a value before the old one has been used.
      nanosvg.h:2907: style: Variable 'fp' is reassigned a value before the old one has been used.

The cause of these warnings is that both variables are set to NULL and then assigned a different value to - which is no bug but adds an unnecessary assignment to the code.