### PR TITLE
Avoid signed integer overflow in nsvg__RGBA()

### DIFF
--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -956,7 +956,7 @@ static float nsvg__clampf(float a, float mn, float mx) { return a < mn ? mn : (a
 
 static unsigned int nsvg__RGBA(unsigned char r, unsigned char g, unsigned char b, unsigned char a)
 {
-	return (r) | (g << 8) | (b << 16) | (a << 24);
+	return ((unsigned int)r) | ((unsigned int)g << 8) | ((unsigned int)b << 16) | ((unsigned int)a << 24);
 }
 
 static unsigned int nsvg__lerpRGBA(unsigned int c0, unsigned int c1, float u)


### PR DESCRIPTION
`a` is implicitly cast to (signed) `int` before shifting, and when `int` is 32-bit, it is undefined behavior to left-shift `a` by 24 when its most significant bit is 1. Error from UBSan (`-fsanitize=shift-base`):

```
nanosvgrast.h:975:41: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
```

Casting `a` to `unsigned int` before shifting avoids undefined behavior.