### PR TITLE
Add CMake build script to the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,12 @@ configure_file(src/nanosvg.h ${CMAKE_CURRENT_BINARY_DIR}/nanosvg.c)
 configure_file(src/nanosvgrast.h ${CMAKE_CURRENT_BINARY_DIR}/nanosvgrast.c)
 
 add_library(nanosvg ${CMAKE_CURRENT_BINARY_DIR}/nanosvg.c)
-target_link_libraries(nanosvg PRIVATE m)
+
+find_library(MATH_LIBRARY m) # Business as usual
+if(MATH_LIBRARY)
+    target_link_libraries(nanosvg PUBLIC ${MATH_LIBRARY})
+endif()
+
 target_include_directories(nanosvg PUBLIC $<INSTALL_INTERFACE:include/nanosvg>)
 target_compile_definitions(nanosvg PRIVATE NANOSVG_IMPLEMENTATION)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(NanoSVG C)
+
+# CMake needs *.c files to do something useful
+configure_file(src/nanosvg.h ${CMAKE_CURRENT_BINARY_DIR}/nanosvg.c)
+configure_file(src/nanosvgrast.h ${CMAKE_CURRENT_BINARY_DIR}/nanosvgrast.c)
+
+add_library(nanosvg ${CMAKE_CURRENT_BINARY_DIR}/nanosvg.c)
+target_link_libraries(nanosvg PRIVATE m)
+target_include_directories(nanosvg PUBLIC $<INSTALL_INTERFACE:include/nanosvg>)
+target_compile_definitions(nanosvg PRIVATE NANOSVG_IMPLEMENTATION)
+
+# Same for nanosvgrast
+add_library(nanosvgrast ${CMAKE_CURRENT_BINARY_DIR}/nanosvgrast.c)
+set_target_properties(nanosvgrast PROPERTIES LINKER_LANGUAGE C)
+target_link_libraries(nanosvgrast PUBLIC nanosvg)
+target_include_directories(nanosvgrast PRIVATE src)
+target_compile_definitions(nanosvgrast PRIVATE NANOSVGRAST_IMPLEMENTATION)
+
+# Installation and export:
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION 1.0
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(TARGETS nanosvg nanosvgrast
+        EXPORT ${PROJECT_NAME}Targets
+)
+
+export(EXPORT ${PROJECT_NAME}Targets 
+       FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake" 
+       NAMESPACE ${PROJECT_NAME}::
+)
+
+set(ConfigPackageLocation lib/cmake/${PROJECT_NAME})
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION ${ConfigPackageLocation}
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+install(
+    FILES
+      src/nanosvg.h
+      src/nanosvgrast.h
+    DESTINATION
+      include/nanosvg
+  )
+
+install(EXPORT ${PROJECT_NAME}Targets
+  FILE
+    ${PROJECT_NAME}Targets.cmake
+  NAMESPACE
+    ${PROJECT_NAME}::
+  DESTINATION
+    ${ConfigPackageLocation}
+)
+
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  DESTINATION
+    ${ConfigPackageLocation}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ target_compile_definitions(nanosvg PRIVATE NANOSVG_IMPLEMENTATION)
 
 # Same for nanosvgrast
 add_library(nanosvgrast ${CMAKE_CURRENT_BINARY_DIR}/nanosvgrast.c)
-set_target_properties(nanosvgrast PROPERTIES LINKER_LANGUAGE C)
 target_link_libraries(nanosvgrast PUBLIC nanosvg)
 target_include_directories(nanosvgrast PRIVATE src)
 target_compile_definitions(nanosvgrast PRIVATE NANOSVGRAST_IMPLEMENTATION)

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/NanoSVGTargets.cmake)
+    include("${CMAKE_CURRENT_LIST_DIR}/NanoSVGTargets.cmake")
+endif ()

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ By default, NanoSVG parses only the most common colors. In order to get support 
 #include "nanosvg.h"
 ```
 
+Alternatively, you can install the library using CMake and import it into your project using the standard CMake `find_package` command.
+
+```CMake
+add_executable(myexe main.c)
+
+find_package(NanoSVG REQUIRED)
+
+target_link_libraries(myexe NanoSVG::nanosvg NanoSVG::nanosvgrast)
+```
+
 ## Compiling Example Project
 
 In order to compile the demo project, your will need to install [GLFW](http://www.glfw.org/) to compile.

--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -187,6 +187,7 @@ void nsvgDelete(NSVGimage* image);
 
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <math.h>
 
 #define NSVG_PI (3.14159265358979323846264338327f)

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -25,6 +25,8 @@
 #ifndef NANOSVGRAST_H
 #define NANOSVGRAST_H
 
+#include "nanosvg.h"
+
 #ifndef NANOSVGRAST_CPLUSPLUS
 #ifdef __cplusplus
 extern "C" {
@@ -77,6 +79,8 @@ void nsvgDeleteRasterizer(NSVGrasterizer*);
 #ifdef NANOSVGRAST_IMPLEMENTATION
 
 #include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define NSVG__SUBSAMPLES	5
 #define NSVG__FIXSHIFT		10


### PR DESCRIPTION
Hello there! I'm sending this PR on behalf of the [PrusaSlicer](https://github.com/prusa3d/PrusaSlicer) team. We are using nanosvg in our software and having trouble with symbol duplication since wxWidgets also started using this library. 

Since both our team and the wxWidgets team is using CMake, I've written the CMake build and install scripts to be able to import the library in both projects without duplication issues.

I've also added a short extension to the readme file to address the new integration method.

I know that this goes somewhat against the philosophy of the library to be simple to integrate and the examples already use a different build system but this is the solution we could provide quickly and believe it would have the most widespread acceptance in the community.