### PR TITLE
Avoid calling `qsort()` when `r->nedges == 0`

### DIFF
--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -1406,7 +1406,8 @@ void nsvgRasterize(NSVGrasterizer* r,
 			}
 
 			// Rasterize edges
-			qsort(r->edges, r->nedges, sizeof(NSVGedge), nsvg__cmpEdge);
+			if (r->nedges != 0)
+				qsort(r->edges, r->nedges, sizeof(NSVGedge), nsvg__cmpEdge);
 
 			// now, traverse the scanlines and find the intersections on each scanline, use non-zero rule
 			nsvg__initPaint(&cache, &shape->fill, shape->opacity);
@@ -1432,7 +1433,8 @@ void nsvgRasterize(NSVGrasterizer* r,
 			}
 
 			// Rasterize edges
-			qsort(r->edges, r->nedges, sizeof(NSVGedge), nsvg__cmpEdge);
+			if (r->nedges != 0)
+				qsort(r->edges, r->nedges, sizeof(NSVGedge), nsvg__cmpEdge);
 
 			// now, traverse the scanlines and find the intersections on each scanline, use non-zero rule
 			nsvg__initPaint(&cache, &shape->stroke, shape->opacity);


### PR DESCRIPTION
During `nsvgRasterize()`, it is possible in some unusual cases for `nsvg__flattenShape()` to not use `nsvg__addEdge()` or for `nsvg__flattenShapeStroke()` to not use `nsvg__expandStroke()` &rarr; `nsvg__addEdge()`, causing `qsort()` to be called with `r->edges == NULL` and `r->nedges == 0`. But apparently `qsort()` should not be called with `NULL` as the array pointer, even when the length is 0; the array pointer for `qsort()` is declared to be non-`NULL`, at least in glibc.

Here is a Tcl/Tk 8.7 syntax example (inspired by the Tcl/Tk test imgSVGnano-1.7 "very small scale gives 1x1 image" which led me to this issue):

```tcl
image create photo foo -format "svg -scale 0.000001" -data {
  <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
    <circle fill="yellow" stroke="red" stroke-width="10001" cx="10" cy="80" r="10" />
  </svg>
}
```

UBSan `-fsanitize=undefined` (more specifically `-fsanitize=nonnull-attribute`) error:

```
tk/unix/../generic/nanosvgrast.h:1426:4: runtime error: null pointer passed as argument 1, which is declared to never be null
    #0 0xb69c3ba0 in nsvgRasterize tk/unix/../generic/nanosvgrast.h:1426
    #1 0xb69c869f in RasterizeSVG tk/unix/../generic/tkImgSVGnano.c:610
    #2 0xb69c5e64 in StringReadSVG tk/unix/../generic/tkImgSVGnano.c:363
    #3 0xb69586fc in ImgPhotoConfigureModel tk/unix/../generic/tkImgPhoto.c:2253
    #4 0xb6938bf5 in ImgPhotoCreate tk/unix/../generic/tkImgPhoto.c:419
    #5 0xb68dd149 in Tk_ImageObjCmd tk/unix/../generic/tkImage.c:371
    #6 0xb4360c19 in Dispatch tcl/generic/tclBasic.c:4471
    #7 0xb4360f56 in TclNRRunCallbacks tcl/generic/tclBasic.c:4487
    #8 0xb435d9cc in Tcl_EvalObjv tcl/generic/tclBasic.c:4230
    #9 0xb436d103 in TclEvalEx tcl/generic/tclBasic.c:5313
    #10 0xb4b4426f in Tcl_FSEvalFileEx tcl/generic/tclIOUtil.c:1783
    #11 0xb65cbf34 in Tk_MainEx tk/unix/../generic/tkMain.c:338
    #12 0x4543db in main tk/unix/../unix/tkAppInit.c:96
    #13 0xb3282258 in __libc_start_call_main (/usr/lib/libc.so.6+0x25258)
    #14 0xb3282333 in __libc_start_main_impl (/usr/lib/libc.so.6+0x25333)
    #15 0x45417a in _start (tcl90p/bin/wish8.7+0x117a)
tk/unix/../generic/nanosvgrast.h:1452:4: runtime error: null pointer passed as argument 1, which is declared to never be null
    #0 0xb69c40ad in nsvgRasterize tk/unix/../generic/nanosvgrast.h:1452
    #1 0xb69c869f in RasterizeSVG tk/unix/../generic/tkImgSVGnano.c:610
    #2 0xb69c5e64 in StringReadSVG tk/unix/../generic/tkImgSVGnano.c:363
    #3 0xb69586fc in ImgPhotoConfigureModel tk/unix/../generic/tkImgPhoto.c:2253
    #4 0xb6938bf5 in ImgPhotoCreate tk/unix/../generic/tkImgPhoto.c:419
    #5 0xb68dd149 in Tk_ImageObjCmd tk/unix/../generic/tkImage.c:371
    #6 0xb4360c19 in Dispatch tcl/generic/tclBasic.c:4471
    #7 0xb4360f56 in TclNRRunCallbacks tcl/generic/tclBasic.c:4487
    #8 0xb435d9cc in Tcl_EvalObjv tcl/generic/tclBasic.c:4230
    #9 0xb436d103 in TclEvalEx tcl/generic/tclBasic.c:5313
    #10 0xb4b4426f in Tcl_FSEvalFileEx tcl/generic/tclIOUtil.c:1783
    #11 0xb65cbf34 in Tk_MainEx tk/unix/../generic/tkMain.c:338
    #12 0x4543db in main tk/unix/../unix/tkAppInit.c:96
    #13 0xb3282258 in __libc_start_call_main (/usr/lib/libc.so.6+0x25258)
    #14 0xb3282333 in __libc_start_main_impl (/usr/lib/libc.so.6+0x25333)
    #15 0x45417a in _start (tcl90p/bin/wish8.7+0x117a)
```

Presumably `qsort()` should be guarded by `if (r->edges != NULL)` (at a minimum this suppresses the UBSan complaint), but maybe there is a better solution which I am not aware of.