### PR TITLE
allow usage in projects using strict prototypes

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -612,7 +612,7 @@ static void nsvg__curveBounds(float* bounds, float* curve)
 	}
 }
 
-static NSVGparser* nsvg__createParser()
+static NSVGparser* nsvg__createParser(void)
 {
 	NSVGparser* p;
 	p = (NSVGparser*)malloc(sizeof(NSVGparser));


### PR DESCRIPTION
Allows using in projects that define `-Werror=strict-prototypes`