### PR TITLE
Fix build when both nanosvg.h and nanosvgrast.h is included

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -181,8 +181,6 @@ void nsvgDelete(NSVGimage* image);
 #endif
 #endif
 
-#endif // NANOSVG_H
-
 #ifdef NANOSVG_IMPLEMENTATION
 
 #include <string.h>
@@ -3008,3 +3006,5 @@ void nsvgDelete(NSVGimage* image)
 }
 
 #endif
+
+#endif // NANOSVG_H

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -74,8 +74,6 @@ void nsvgDeleteRasterizer(NSVGrasterizer*);
 #endif
 #endif
 
-#endif // NANOSVGRAST_H
-
 #ifdef NANOSVGRAST_IMPLEMENTATION
 
 #include <math.h>
@@ -1456,3 +1454,5 @@ void nsvgRasterize(NSVGrasterizer* r,
 }
 
 #endif
+
+#endif // NANOSVGRAST_H


### PR DESCRIPTION
This PR fixes the build without removing `#include "nanosvg.h"` from nanosvgrast.h