### PR TITLE
Vertically flipped rasterization

### DIFF
--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -148,6 +148,8 @@ struct NSVGrasterizer
 
 	unsigned char* bitmap;
 	int width, height, stride;
+
+	bool loadFlipped;
 };
 
 NSVGrasterizer* nsvgCreateRasterizer()
@@ -1196,7 +1198,8 @@ static void nsvg__rasterizeSortedEdges(NSVGrasterizer *r, float tx, float ty, fl
 		if (xmin < 0) xmin = 0;
 		if (xmax > r->width-1) xmax = r->width-1;
 		if (xmin <= xmax) {
-			nsvg__scanlineSolid(&r->bitmap[y * r->stride] + xmin*4, xmax-xmin+1, &r->scanline[xmin], xmin, y, tx,ty, scale, cache);
+			int yy = r->loadFlipped ? r->height - y - 1 : y;
+			nsvg__scanlineSolid(&r->bitmap[yy * r->stride] + xmin*4, xmax-xmin+1, &r->scanline[xmin], xmin, y, tx,ty, scale, cache);
 		}
 	}
 


### PR DESCRIPTION
Allow to rasterize the image vertically flipped for better compatibility with OpenGL textures.