### PR TITLE
Fix newline at end of file, add comments

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -3005,6 +3005,6 @@ void nsvgDelete(NSVGimage* image)
 	free(image);
 }
 
-#endif
+#endif // NANOSVG_IMPLEMENTATION
 
 #endif // NANOSVG_H

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -1453,6 +1453,6 @@ void nsvgRasterize(NSVGrasterizer* r,
 	r->stride = 0;
 }
 
-#endif
+#endif // NANOSVGRAST_IMPLEMENTATION
 
 #endif // NANOSVGRAST_H


### PR DESCRIPTION
Fix "No newline at end of file" warning. The newline was removed by commit 47f28a2a78de610, probably unintentionally.

Add missing comments to #endif statements for clarity and consistency.

Some of the `#endif` statements had comments, others didn't. I added the missing comments.

This PR is pure "cosmetic", it doesn't affect compilation.
