### PR TITLE
change struct NSVGpaint:type to signed char

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -398,7 +398,7 @@ typedef struct NSVGgradientData
 {
 	char id[64];
 	char ref[64];
-	char type;
+	signed char type;
 	union {
 		NSVGlinearData linear;
 		NSVGradialData radial;
@@ -818,7 +818,7 @@ static NSVGgradientData* nsvg__findGradientData(NSVGparser* p, const char* id)
 	return NULL;
 }
 
-static NSVGgradient* nsvg__createGradient(NSVGparser* p, const char* id, const float* localBounds, float *xform, char* paintType)
+static NSVGgradient* nsvg__createGradient(NSVGparser* p, const char* id, const float* localBounds, float *xform, signed char* paintType)
 {
 	NSVGgradientData* data = NULL;
 	NSVGgradientData* ref = NULL;
@@ -2636,7 +2636,7 @@ static void nsvg__parseSVG(NSVGparser* p, const char** attr)
 	}
 }
 
-static void nsvg__parseGradient(NSVGparser* p, const char** attr, char type)
+static void nsvg__parseGradient(NSVGparser* p, const char** attr, signed char type)
 {
 	int i;
 	NSVGgradientData* grad = (NSVGgradientData*)malloc(sizeof(NSVGgradientData));

--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -120,7 +120,7 @@ typedef struct NSVGgradient {
 } NSVGgradient;
 
 typedef struct NSVGpaint {
-	char type;
+	signed char type;
 	union {
 		unsigned int color;
 		NSVGgradient* gradient;

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -114,7 +114,7 @@ typedef struct NSVGmemPage {
 } NSVGmemPage;
 
 typedef struct NSVGcachedPaint {
-	char type;
+	signed char type;
 	char spread;
 	float xform[6];
 	unsigned int colors[256];


### PR DESCRIPTION
Commit 34a6c493 added NSVG_PAINT_UNDEF as -1. For this to work correctly
where char is unsigned by default, struct NSVGpaint::type needs changing
to explicit signed char. (An 'int' would work too, but I did not want to
change the size of the stucture.)