### PR TITLE
Change default (unspecified) strokeWidth to 0

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -634,7 +634,7 @@ static NSVGparser* nsvg__createParser(void)
 	p->attr[0].fillOpacity = 1;
 	p->attr[0].strokeOpacity = 1;
 	p->attr[0].stopOpacity = 1;
-	p->attr[0].strokeWidth = 1;
+	p->attr[0].strokeWidth = 0;
 	p->attr[0].strokeLineJoin = NSVG_JOIN_MITER;
 	p->attr[0].strokeLineCap = NSVG_CAP_BUTT;
 	p->attr[0].miterLimit = 4;


### PR DESCRIPTION
Stroke width should read as 0 if not specified according to SVG spec. Transforms that scale objects should not scale an unspecified stroke width. This change sets the default stroke width to 0 instead of 1, making nanosvg comply with that aspect of the specification. Fixes #238