### PR TITLE
Fix cmake library installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ export(EXPORT ${PROJECT_NAME}Targets
        NAMESPACE ${PROJECT_NAME}::
 )
 
-set(ConfigPackageLocation lib/cmake/${PROJECT_NAME})
+set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"


### PR DESCRIPTION
Linux distributions have platform dependend library directories (`lib64` vs `lib`). Use the standard and configurable `CMAKE_INSTALL_LIBDIR` variable, instead of a hardcoded `lib`.