### PR TITLE
Fix drawing artifacts due to rounding errors.

### DIFF
--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -331,6 +331,7 @@ static float nsvg__normalize(float *x, float* y)
 }
 
 static float nsvg__absf(float x) { return x < 0 ? -x : x; }
+static float nsvg__roundf(float x) { return (x > 0) ? floorf(x + 0.5) : ceilf(x + 0.5); }
 
 static void nsvg__flattenCubicBez(NSVGrasterizer* r,
 								  float x1, float y1, float x2, float y2,
@@ -872,10 +873,10 @@ static NSVGactiveEdge* nsvg__addActive(NSVGrasterizer* r, NSVGedge* e, float sta
 //	STBTT_assert(e->y0 <= start_point);
 	// round dx down to avoid going too far
 	if (dxdy < 0)
-		z->dx = (int)(-floorf(NSVG__FIX * -dxdy));
+		z->dx = (int)(-nsvg__roundf(NSVG__FIX * -dxdy));
 	else
-		z->dx = (int)floorf(NSVG__FIX * dxdy);
-	z->x = (int)floorf(NSVG__FIX * (e->x0 + dxdy * (startPoint - e->y0)));
+		z->dx = (int)nsvg__roundf(NSVG__FIX * dxdy);
+	z->x = (int)nsvg__roundf(NSVG__FIX * (e->x0 + dxdy * (startPoint - e->y0)));
 //	z->x -= off_x * FIX;
 	z->ey = e->y1;
 	z->next = 0;


### PR DESCRIPTION
This patch fixes issue #130.

I have seen that there are already some for fixing those graphic glitches, but in my opinion they are not exactly correct.
Increasing the value of `NSVG__FIXSHIFT` just hides the real cause of the problem.
In my opinion, there is a mathematical error into the conversion from the floating point value to fixed point.
Here, the code is using `floorf()` for converting the floating point value to integer, but I think that this is wrong because it does not take care of the remaining valid digits of that number.
Rounding to the nearest high or low integer value discards the value of those valid digits, not included into the fractional part of the fixed point number.
As result, this error is accumulated on each step and, at the end, the limit of the integral does not converge to the expected value.
That's why increasing `NSVG__FIXSHIFT` apparently fixes the issue, but in my opinion a better solution is to change how the integer value is converted and keeping `NSVG__FIXSHIFT` as it is, at least for now.

In other words, `floorf()` simply needs to be replaced with `roundf()`.
This patch has fixed the test case included into the issue #130 and probably other drawing misalignments.
