### PR TITLE
Fixed invalid memory read on single stop gradient

### DIFF
--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -1284,8 +1284,9 @@ static void nsvg__initPaint(NSVGcachedPaint* cache, NSVGpaint* paint, float opac
 		for (i = 0; i < 256; i++)
 			cache->colors[i] = 0;
 	} else if (grad->nstops == 1) {
+		unsigned int color = nsvg__applyOpacity(grad->stops[0].color, opacity);
 		for (i = 0; i < 256; i++)
-			cache->colors[i] = nsvg__applyOpacity(grad->stops[i].color, opacity);
+			cache->colors[i] = color;
 	} else {
 		unsigned int ca, cb = 0;
 		float ua, ub, du, u;


### PR DESCRIPTION
I was tinkering the code when i came up with a invalid memory read on the rasterizer. When the gradient had only 1 stop, it attempted to read from multiple out of bounds places through `grad->stops[i].color`. I changed it to read only the first stop color and furthermore cache the calculated color since it will not change through the loop.