### PR TITLE
nanosvg.h (nsvg__parseTransform): initialize the local float t[0]

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -1653,7 +1653,7 @@ static int nsvg__parseRotate(float* xform, const char* str)
 
 static void nsvg__parseTransform(float* xform, const char* str)
 {
-	float t[6];
+	float t[6] = { 0 };
 	int len;
 	nsvg__xformIdentity(xform);
 	while (*str)


### PR DESCRIPTION
Silences -Wmaybe-uninitialized warnings from gcc-14

```
In function 'nsvg__xformMultiply',
    inlined from 'nsvg__xformPremultiply' at /tmp/nanosvg/b/nanosvg.c:536:2,
    inlined from 'nsvg__parseTransform' at /tmp/nanosvg/b/nanosvg.c:1684:3:
/tmp/nanosvg/b/nanosvg.c:505:25: warning: 't[0]' may be used uninitialized [-Wmaybe-uninitialized]
  505 |         float t0 = t[0] * s[0] + t[1] * s[2];
      |                    ~~~~~^~~~~~
/tmp/nanosvg/b/nanosvg.c: In function 'nsvg__parseTransform':
/tmp/nanosvg/b/nanosvg.c:1656:15: note: 't[0]' was declared here
 1656 |         float t[6];
      |               ^
In function 'nsvg__xformMultiply',
    inlined from 'nsvg__xformPremultiply' at /tmp/nanosvg/b/nanosvg.c:536:2,
    inlined from 'nsvg__parseTransform' at /tmp/nanosvg/b/nanosvg.c:1684:3:
/tmp/nanosvg/b/nanosvg.c:505:39: warning: 't[1]' may be used uninitialized [-Wmaybe-uninitialized]
  505 |         float t0 = t[0] * s[0] + t[1] * s[2];
      |                                  ~~~~~^~~~~~
/tmp/nanosvg/b/nanosvg.c: In function 'nsvg__parseTransform':
/tmp/nanosvg/b/nanosvg.c:1656:15: note: 't[1]' was declared here
 1656 |         float t[6];
      |               ^
In function 'nsvg__xformMultiply',
    inlined from 'nsvg__xformPremultiply' at /tmp/nanosvg/b/nanosvg.c:536:2,
    inlined from 'nsvg__parseTransform' at /tmp/nanosvg/b/nanosvg.c:1684:3:
/tmp/nanosvg/b/nanosvg.c:509:21: warning: 't[2]' may be used uninitialized [-Wmaybe-uninitialized]
  509 |         t[3] = t[2] * s[1] + t[3] * s[3];
      |                ~~~~~^~~~~~
/tmp/nanosvg/b/nanosvg.c: In function 'nsvg__parseTransform':
/tmp/nanosvg/b/nanosvg.c:1656:15: note: 't[2]' was declared here
 1656 |         float t[6];
      |               ^
In function 'nsvg__xformMultiply',
    inlined from 'nsvg__xformPremultiply' at /tmp/nanosvg/b/nanosvg.c:536:2,
    inlined from 'nsvg__parseTransform' at /tmp/nanosvg/b/nanosvg.c:1684:3:
/tmp/nanosvg/b/nanosvg.c:509:35: warning: 't[3]' may be used uninitialized [-Wmaybe-uninitialized]
  509 |         t[3] = t[2] * s[1] + t[3] * s[3];
      |                              ~~~~~^~~~~~
/tmp/nanosvg/b/nanosvg.c: In function 'nsvg__parseTransform':
/tmp/nanosvg/b/nanosvg.c:1656:15: note: 't[3]' was declared here
 1656 |         float t[6];
      |               ^
In function 'nsvg__xformMultiply',
    inlined from 'nsvg__xformPremultiply' at /tmp/nanosvg/b/nanosvg.c:536:2,
    inlined from 'nsvg__parseTransform' at /tmp/nanosvg/b/nanosvg.c:1684:3:
/tmp/nanosvg/b/nanosvg.c:510:21: warning: 't[4]' may be used uninitialized [-Wmaybe-uninitialized]
  510 |         t[5] = t[4] * s[1] + t[5] * s[3] + s[5];
      |                ~~~~~^~~~~~
/tmp/nanosvg/b/nanosvg.c: In function 'nsvg__parseTransform':
/tmp/nanosvg/b/nanosvg.c:1656:15: note: 't[4]' was declared here
 1656 |         float t[6];
      |               ^
In function 'nsvg__xformMultiply',
    inlined from 'nsvg__xformPremultiply' at /tmp/nanosvg/b/nanosvg.c:536:2,
    inlined from 'nsvg__parseTransform' at /tmp/nanosvg/b/nanosvg.c:1684:3:
/tmp/nanosvg/b/nanosvg.c:510:35: warning: 't[5]' may be used uninitialized [-Wmaybe-uninitialized]
  510 |         t[5] = t[4] * s[1] + t[5] * s[3] + s[5];
      |                              ~~~~~^~~~~~
/tmp/nanosvg/b/nanosvg.c: In function 'nsvg__parseTransform':
/tmp/nanosvg/b/nanosvg.c:1656:15: note: 't[5]' was declared here
 1656 |         float t[6];
      |               ^
```
