### PR TITLE
Fix OOB read in nsvg__parseColorRGB()

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -1265,7 +1265,7 @@ static unsigned int nsvg__parseColorRGB(const char* str)
 				while (*str && nsvg__isdigit(*str)) str++;	// skip fractional part
 			}
 			if (*str == '%') str++; else break;
-			while (nsvg__isspace(*str)) str++;
+			while (*str && nsvg__isspace(*str)) str++;
 			if (*str == delimiter[i]) str++;
 			else break;
 		}


### PR DESCRIPTION
nsvg__isspace uses strchr on a NUL terminated string, so it returns true for the NUL terminator.  Other uses of nsvg__isspace account for this by checking for NUL first; I've followed the same pattern here.

Fixes #241.