### PR TITLE
Add missing NaN check in nsvg__clampf

### DIFF
--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -956,7 +956,7 @@ static void nsvg__fillActiveEdges(unsigned char* scanline, int len, NSVGactiveEd
 }
 
 static float nsvg__clampf(float a, float mn, float mx) {
-	if ((a >= 0.0f) == (a < 0.0f))
+	if (isnan(a))
 		return mn;
 	return a < mn ? mn : (a > mx ? mx : a);
 }

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -955,7 +955,11 @@ static void nsvg__fillActiveEdges(unsigned char* scanline, int len, NSVGactiveEd
 	}
 }
 
-static float nsvg__clampf(float a, float mn, float mx) { return a < mn ? mn : (a > mx ? mx : a); }
+static float nsvg__clampf(float a, float mn, float mx) {
+	if ((a >= 0.0f) == (a < 0.0f))
+		return mn;
+	return a < mn ? mn : (a > mx ? mx : a);
+}
 
 static unsigned int nsvg__RGBA(unsigned char r, unsigned char g, unsigned char b, unsigned char a)
 {


### PR DESCRIPTION
The result of clampf is cast to int to access the "colors" array in some places, but without a NaN check the conversion can return some undefined value (often negative), leading to OOB access.

(I put the check in clampf because all call sites cast the result to int anyway, and NaN -> int is UB in general.)