### PR TITLE
Fix missing call to nsvg__prepareStroke() in leftover stroke path (#276)

### DIFF
--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -835,8 +835,10 @@ static void nsvg__flattenShapeStroke(NSVGrasterizer* r, NSVGshape* shape, float 
 				}
 			}
 			// Stroke any leftover path
-			if (r->npoints > 1 && dashState)
+			if (r->npoints > 1 && dashState) {
+				nsvg__prepareStroke(r, miterLimit, lineJoin);
 				nsvg__expandStroke(r, r->points, r->npoints, 0, lineJoin, lineCap, lineWidth);
+			}
 		} else {
 			nsvg__prepareStroke(r, miterLimit, lineJoin);
 			nsvg__expandStroke(r, r->points, r->npoints, closed, lineJoin, lineCap, lineWidth);


### PR DESCRIPTION
This pull request fixes an issue reported in #276 where dashed strokes can
occasionally render incorrectly.

The problem occurs in `nsvg__flattenShapeStroke()` when the code enters the
"Stroke any leftover path" block. Unlike the other stroke paths, this branch
does not call `nsvg__prepareStroke()` before invoking `nsvg__expandStroke()`,
which results in inconsistent stroke behavior and, in some cases, corrupted
rendering output.

This patch adds the missing `nsvg__prepareStroke()` call to make the behavior
consistent with the rest of the stroke-handling logic.