### PR TITLE
Move _IMPLEMENTATION outside of _H

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -192,6 +192,8 @@ void nsvgDelete(NSVGimage* image);
 #endif
 #endif
 
+#endif // NANOSVG_H
+
 #ifdef NANOSVG_IMPLEMENTATION
 
 #include <string.h>
@@ -3128,5 +3130,3 @@ void nsvgDelete(NSVGimage* image)
 }
 
 #endif // NANOSVG_IMPLEMENTATION
-
-#endif // NANOSVG_H

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -74,6 +74,8 @@ void nsvgDeleteRasterizer(NSVGrasterizer*);
 #endif
 #endif
 
+#endif // NANOSVGRAST_H
+
 #ifdef NANOSVGRAST_IMPLEMENTATION
 
 #include <math.h>
@@ -1468,5 +1470,3 @@ void nsvgRasterize(NSVGrasterizer* r,
 }
 
 #endif // NANOSVGRAST_IMPLEMENTATION
-
-#endif // NANOSVGRAST_H


### PR DESCRIPTION
In my project multiple files want to include nanosvg.h.
I also like to add all `#define *_IMPLEMENTATION` at the end of main.c, just to keep things in one place.

My usage:
```c
#include "example.h" // includes nanosvg.h

...

int main(void) { ... }

#define NANOSVG_IMPLEMENTATION
#include "nanosvg.h"

#define NANOSVGRAST_IMPLEMENTATION
#include "nanosvgrast.h"
```

Currently this is not possible because if the implementation is not included the first time, it will never be included, since it's declared inside of `NANOSVG_H` guard. With the new change, you can do this.

One possible issue I see is that if the user declares `NANOSVG_IMPLEMENTATION` early, then all successive includes will produce an error (since implementation will keep getting added multiple times). I feel like this is good and should not be solved by the library, since it is not trying to hide information from the user and gives them proper understanding of what is going on. It is also easily solvable with an `#undef`. I don't insist on this decision though, if you disagree.