### PR TITLE
Fix silent gap in nsvg__pathArcTo for huge-radii arcs

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -2250,6 +2250,18 @@ static void nsvg__pathArcTo(NSVGparser* p, float* cpx, float* cpy, float* args, 
 	else if (fs == 1 && da < 0)
 		da += 2 * NSVG_PI;
 
+	// If the swept angle is too small for the kappa formula to be numerically
+	// reliable, the arc degenerates to a line. (1 - cos(hda)) / sin(hda)
+	// suffers catastrophic cancellation in float32 when hda < ~1e-3, which
+	// corresponds to |da| < ~2e-3 (ndivs = 1 in this range, so hda = da/2).
+	// Also covers the huge-radii / tiny-chord case where da collapses to ~0.
+	if (fabsf(da) < 2e-3f) {
+		nsvg__lineTo(p, x2, y2);
+		*cpx = x2;
+		*cpy = y2;
+		return;
+	}
+
 	// Approximate the arc using cubic spline segments.
 	t[0] = cosrx; t[1] = sinrx;
 	t[2] = -sinrx; t[3] = cosrx;
@@ -2259,12 +2271,7 @@ static void nsvg__pathArcTo(NSVGparser* p, float* cpx, float* cpy, float* args, 
 	// The loop assumes an iteration per end point (including start and end), this +1.
 	ndivs = (int)(fabsf(da) / (NSVG_PI*0.5f) + 1.0f);
 	hda = (da / (float)ndivs) / 2.0f;
-	// Fix for ticket #179: division by 0: avoid cotangens around 0 (infinite)
-	if ((hda < 1e-3f) && (hda > -1e-3f))
-		hda *= 0.5f;
-	else
-		hda = (1.0f - cosf(hda)) / sinf(hda);
-	kappa = fabsf(4.0f / 3.0f * hda);
+	kappa = fabsf(4.0f / 3.0f * (1.0f - cosf(hda)) / sinf(hda));
 	if (da < 0.0f)
 		kappa = -kappa;
 


### PR DESCRIPTION

  Fixes #285.

  ## Summary

  When an SVG arc has very large radii relative to the chord between its endpoints, the computed
  swept angle `da` rounds to `0` in float32. The existing "Fix for ticket #179" prevents `kappa`
  from going NaN but leaves a **silent gap** in the path: the bezier loop emits zero-length curves
  while `*cpx, *cpy` advance to `(x2, y2)`, so subsequent path commands resume at `(x2, y2)` with no   segment drawn between `(x1, y1)` and `(x2, y2)`.

  This PR replaces the small-angle `hda` branch with a single `|da| < 2e-3f` early-out that emits a
  line to the end point. The new threshold subsumes the ticket-#179 case (`|hda| < 1e-3` with `ndivs   = 1` implies `|da| < 2e-3`), so the textbook `(1 - cos(hda)) / sin(hda)` formula can be restored.
  See the linked issue for a full trace and a reproducer SVG.

  ## Changes

  - `nsvg__pathArcTo`: add `|da| < 2e-3f` early-out after the sweep-flag adjustment; emit
  `nsvg__lineTo(x2, y2)` and return.
  - Remove the now-redundant `|hda| < 1e-3f` branch (the new guard fires earlier, in all the same
  cases).
  - Restore the original textbook `kappa = (4/3) * (1 - cos(hda)) / sin(hda)` formula in a single
  line.

  Net diff: +13 / −6.

  ## Test plan

  - [x] `huge_radius_arc.svg` (attached to the linked issue) renders without the gap.
  - [x] Regression test on a corpus of normal SVGs — visually identical output (only arcs with `|da|   < 2e-3 rad ≈ 0.11°` change behavior, and they're sub-pixel at any realistic scale).
  - [x] No new compiler warnings (single-precision math only; nothing added that touches the
  `<math.h>` surface).